### PR TITLE
Added support for open source ILP solver glpk via pyomo

### DIFF
--- a/src/MaCroDNA/macrodna.py
+++ b/src/MaCroDNA/macrodna.py
@@ -86,7 +86,7 @@ class MaCroDNA:
     def cell2cell_assignment(self):
         dna_cells = list(self.dna_df.columns)
         rna_cells = list(self.rna_df.columns)
-        genes = set(self.dna_df.index).intersection(self.rna_df.index.to_list())
+        genes = list(set(self.dna_df.index).intersection(self.rna_df.index.to_list()))
         self.dna_df = self.dna_df.loc[genes,:]
         self.rna_df = self.rna_df.loc[genes,:]
 

--- a/test/test_macrodna.py
+++ b/test/test_macrodna.py
@@ -1,4 +1,6 @@
-from MaCroDNA import MaCroDNA
+import sys 
+sys.path.append("./src/MaCroDNA")
+from macrodna import MaCroDNA
 import pandas as pd
 
 if __name__ == '__main__':
@@ -8,6 +10,8 @@ if __name__ == '__main__':
     dna_cluster = pd.read_csv(DataFolder + "dna_cluster.csv", index_col=0)
     run_model = MaCroDNA(rna_df, dna_df, dna_cluster)
     cell2cell = run_model.cell2cell_assignment()
+
+    print(cell2cell)
     cell2clone = run_model.cell2clone_assignment()
     print("**********************")
     print("TEST FINISHED")

--- a/test/test_macrodna.py
+++ b/test/test_macrodna.py
@@ -1,6 +1,4 @@
-import sys 
-sys.path.append("./src/MaCroDNA")
-from macrodna import MaCroDNA
+from MaCroDNA import MaCroDNA
 import pandas as pd
 
 if __name__ == '__main__':

--- a/tinytest.py
+++ b/tinytest.py
@@ -1,0 +1,6 @@
+import os
+import sys 
+sys.path.append("./src/MaCroDNA")
+from macrodna import MaCroDNA
+test_macrodna = MaCroDNA()
+test_macrodna.tiny_test()

--- a/tinytest.py
+++ b/tinytest.py
@@ -1,6 +1,0 @@
-import os
-import sys 
-sys.path.append("./src/MaCroDNA")
-from macrodna import MaCroDNA
-test_macrodna = MaCroDNA()
-test_macrodna.tiny_test()


### PR DESCRIPTION
Users can specify the `solver` parameter as either `gurobi` or `glpk` when initiated the MaCroDNA class. The packages needed to run the ILP solver will be imported when the corresponding function is called. [pyomo](https://pyomo.readthedocs.io/en/stable/installation.html) and [glpk](https://www.gnu.org/software/glpk/#introduction) can be installed via conda-forge or pip. 